### PR TITLE
【feature】投稿一覧ページの作成

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,23 @@
+class PostsController < ApplicationController
+  
+  def index
+    @posts = Post.includes(:user).all
+
+    # 検索機能
+    if params[:search].present?
+      @posts = @posts.where("title ILIKE ?", "%#{params[:search]}%")
+    end
+
+    # カテゴリフィルタ
+    if params[:category].present? && params[:category] != 'All'
+      @posts = @posts.where(category_id: params[:category])
+    end
+
+    # カテゴリ一覧を取得（ビューで表示するため）
+    @categories = Post.select(:category_id).distinct.pluck(:category_id)
+  end
+
+  # def show
+  #   @post = Post.find(params[:id])
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -50,9 +50,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
     devise_parameter_sanitizer.permit(:account_update, keys: [:username])
   end
 
-  # The path used after sign up.
+  # サインアップ後にリダイレクトするパスを指定
   def after_sign_up_path_for(resource)
-    super(resource)
+    posts_path
   end
 
   # The path used after sign up for inactive accounts.

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -18,10 +18,14 @@ class Users::SessionsController < Devise::SessionsController
   #   super
   # end
 
-  # protected
+  protected
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+  # ログイン後にリダイレクトするパスを指定
+  def after_sign_in_path_for(resource)
+    posts_path
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,3 @@
+class Post < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  
   validates :username, presence: true, uniqueness: { case_sensitive: false }, length: { minimum: 3, maximum: 25 }
+
+  # Userが削除されたときに関連するPostも削除される
+  has_many :posts, dependent: :destroy
 end

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,0 +1,12 @@
+<div class="card bg-base-100 shadow-xl">
+  <div class="card-body">
+    <h2 class="card-title"><%= link_to post.title, post_path(post) %></h2>
+    <p class="text-sm text-gray-600">by <%= post.user.name %> on <%= post.created_at.strftime("%Y-%m-%d") %></p>
+    <p class="mt-2"><%= truncate(post.summary, length: 100) %></p>
+    <div class="card-actions justify-end mt-4">
+      <%= link_to '詳細', post_path(post), class: "btn btn-sm btn-primary" %>
+      <!-- ブックマークボタン（後で実装） -->
+      <button class="btn btn-sm btn-outline">ブックマーク</button>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,28 @@
+<div class="container mx-auto px-4 py-8">
+  <!-- 検索バー -->
+  <div class="flex justify-center mb-4">
+    <form method="get" action="<%= posts_path %>" class="w-full max-w-md">
+      <div class="input-group">
+        <input type="text" name="search" value="<%= params[:search] %>" placeholder="タイトルやタグなどから投稿を検索する" class="input input-bordered w-full" />
+        <button type="submit" class="btn btn-primary ml-2">検索</button>
+      </div>
+    </form>
+  </div>
+
+  <!-- カテゴリタブ -->
+  <div class="flex justify-center mb-6">
+    <%= link_to 'すべて', posts_path, class: "btn btn-outline #{'btn-active' if params[:category].blank? || params[:category] == 'All'} mr-2" %>
+    <% @categories.each do |category| %>
+      <%= link_to category, posts_path(category: category), class: "btn btn-outline #{'btn-active' if params[:category] == category} mr-2" %>
+    <% end %>
+  </div>
+
+  <!-- 投稿一覧 -->
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+    <% if @posts.present? %>
+      <%= render @posts %>
+    <% else %>
+      <p class="text-center">投稿がありません。</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -6,7 +6,7 @@
       <p class="py-6 text-base lg:text-lg">
         ランニングで学んだことを共有しよう
       </p>
-      <button class="btn btn-primary">投稿をみる</button>
+      <%= link_to "投稿をみる", posts_path, class: "btn btn-primary" %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,26 +1,25 @@
 Rails.application.routes.draw do
-  devise_for :users,
-  path: '',
-  path_names: {
-    sign_up: '',
-    sign_in: 'login',
-    sign_out: 'logout',
-    registration: "signup",
-  },
-  controllers: {
-    registrations: "users/registrations",
-  }
   root "static_pages#top"
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
+  devise_for :users,
+             path: '',
+             path_names: {
+               sign_up: '',
+               sign_in: 'login',
+               sign_out: 'logout',
+               registration: 'signup'
+             },
+             controllers: {
+               registrations: 'users/registrations',
+               sessions: 'users/sessions'
+             }
+
+  resources :posts, only: %i[index]
+
+  # Health check ルート（アップタイムモニタリング用）
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Render dynamic PWA files from app/views/pwa/*
+  # PWA サポート用の動的ルート
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-
-  # Defines the root path route ("/")
-  # root "posts#index"
 end

--- a/db/migrate/20241102020037_create_posts.rb
+++ b/db/migrate/20241102020037_create_posts.rb
@@ -1,0 +1,14 @@
+class CreatePosts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :posts do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title, null: false
+      t.text :content, null: false
+      t.integer :category_id, null: false
+      t.integer :status, null: false
+      t.string :image
+      t.text :ai_corrected_content
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_30_072053) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_02_020037) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "posts", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "title", null: false
+    t.text "content", null: false
+    t.integer "category_id", null: false
+    t.integer "status", null: false
+    t.string "image"
+    t.text "ai_corrected_content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -27,4 +40,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_30_072053) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end
+
+  add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
### 概要
投稿一覧ページを実装し、ユーザーがログイン後やトップページの「投稿を見る」ボタン、フッターのホームボタンから投稿一覧ページにアクセスできるよう導線を整備。

### 行ったところ
* Postモデル・Postsテーブルを生成する
* app/models/post.rbを編集する
* マイグレーションファイルの編集する
* 掲示版一覧画面へのルーティング設定する
* 設定したルーティングに対応するコントローラーとアクションを用意する
* 用意したコントローラーとアクションに対応するビューを用意する
* 投稿カードなど、再利用可能なコンポーネントをパーシャルとして作成
* 投稿が存在しない場合にメッセージを表示するよう、index.html.erbで条件分岐を実装
* sessions_controller.rbへログイン後にリダイレクトするパスを指定
* config/routes.rbでDeviseのsessionsコントローラーをカスタムコントローラーに指定
* トップページの「投稿を見る」ボタンとフッターのホームボタンに投稿一覧ページへのリンクを追加

### 関連ISSUE
closed #62 #63 #64