### PR TITLE
Feature/#11 新規投稿ページの作成

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -16,6 +16,11 @@ class PostsController < ApplicationController
     @categories = Post.select(:category_id).distinct.pluck(:category_id)
   end
 
+  def new
+    @post = Post.new
+  end
+
+
   # def show
   #   @post = Post.find(params[:id])
   # end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,18 +1,17 @@
 class PostsController < ApplicationController
+  before_action :authenticate_user!
+
   def index
     @posts = Post.includes(:user).all
 
-    # 検索機能
     if params[:search].present?
       @posts = @posts.where("title ILIKE ?", "%#{params[:search]}%")
     end
 
-    # カテゴリフィルタ
     if params[:category].present? && params[:category] != "All"
       @posts = @posts.where(category_id: params[:category])
     end
 
-    # カテゴリ一覧を取得（ビューで表示するため）
     @categories = Post.select(:category_id).distinct.pluck(:category_id)
   end
 
@@ -20,8 +19,19 @@ class PostsController < ApplicationController
     @post = Post.new
   end
 
+  def create
+    @post = current_user.posts.build(post_params)
+    if @post.save
+      redirect_to posts_path, notice: "投稿しました"
+    else
+      flash.now[:danger] = "投稿に失敗しました"
+      render :new, status: :unprocessable_entity
+    end
+  end
 
-  # def show
-  #   @post = Post.find(params[:id])
-  # end
+  private
+
+  def post_params
+    params.require(:post).permit(:title, :content, :category_id, :image, :ai_corrected_content, :reference_url, tag_ids: [])
+  end  
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,4 +3,8 @@ class Post < ApplicationRecord
   belongs_to :category
   has_many :post_tags, dependent: :destroy
   has_many :tags, through: :post_tags
+
+  validates :title, presence: true, length: { maximum: 30 }
+  validates :content, presence: true,length: { maximum: 1000 }
+  validates :category_id, presence: true
 end

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,10 +1,10 @@
 <div class="card bg-base-100 shadow-xl">
   <div class="card-body">
-    <h2 class="card-title"><%= link_to post.title, post_path(post) %></h2>
-    <p class="text-sm text-gray-600">by <%= post.user.name %> on <%= post.created_at.strftime("%Y-%m-%d") %></p>
-    <p class="mt-2"><%= truncate(post.summary, length: 100) %></p>
+    <h2 class="card-title"><%= link_to post.title, "#" %></h2>
+    <p class="text-sm text-gray-600">by <%= post.user.username %> on <%= post.created_at.strftime("%Y-%m-%d") %></p>
+    <p class="mt-2"><%= truncate(post.content, length: 100) %></p>
     <div class="card-actions justify-end mt-4">
-      <%= link_to '詳細', post_path(post), class: "btn btn-sm btn-primary" %>
+      <%= link_to '詳細', "#", class: "btn btn-sm btn-primary" %>
       <!-- ブックマークボタン（後で実装） -->
       <button class="btn btn-sm btn-outline">ブックマーク</button>
     </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -7,36 +7,22 @@
   </div>
 
   <div class="form-control">
-    <label class="label">カテゴリーを選択してください</label>
-    <div class="flex space-x-4">
-      <% Category.all.each do |category| %>
-        <label class="cursor-pointer label">
-          <%= form.radio_button :category_id, category.id, class: "radio" %>
-          <span class="ml-2 text-sm"><%= category.name %></span>
-        </label>
-      <% end %>
-    </div>
+  <label class="label">カテゴリーを選択してください</label>
+  <div class="flex space-x-4">
+    <% Category.all.each do |category| %>
+      <label class="cursor-pointer label">
+        <%= form.radio_button :category_id, category.id, class: "radio category-radio", data: { category_id: category.id } %>
+        <span class="ml-2 text-sm"><%= category.name %></span>
+      </label>
+    <% end %>
   </div>
+</div>
 
-  <div class="form-control">
-    <label class="label">タグを選択してください</label>
-    <div class="flex flex-wrap space-x-4">
-      <% Tag.all.each do |tag| %>
-        <label class="cursor-pointer label">
-          <%= form.check_box :tag_ids, { multiple: true }, tag.id, nil, class: "checkbox" %>
-          <span class="ml-2 text-sm"><%= tag.name %></span>
-        </label>
-      <% end %>
-    </div>
-  </div>
 
   <div class="form-control">
     <%= form.text_area :content, placeholder: "本文を入力してください", class: "textarea textarea-bordered w-full h-40" %>
   </div>
 
-  <div class="form-control">
-    <button type="button" id="ai-correction-button" class="btn btn-primary w-full">AI校正をする</button>
-  </div>
 
   <div class="form-control">
     <%= form.file_field :image, class: "file-input file-input-bordered w-full" %>
@@ -48,15 +34,7 @@
   </div>
 
   <div class="form-control flex space-x-4">
-    <%= link_to "キャンセル", root_path, class: "btn btn-secondary flex-1" %>
-    <%= form.submit "下書き保存", name: "draft", class: "btn btn-outline flex-1" %>
+    <%= link_to "キャンセル", posts_path, class: "btn btn-secondary flex-1" %>
     <%= form.submit "投稿する", class: "btn btn-primary flex-1" %>
   </div>
 <% end %>
-
-<script>
-  document.getElementById("ai-correction-button").addEventListener("click", function() {
-    // モーダルでAI校正結果を表示する処理をここに追加します
-    alert("AI校正を実行しました。");
-  });
-</script>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,62 @@
+<h1 class="text-3xl font-bold text-center mb-8">新規投稿</h1>
+
+<%= form_with model: @post, local: true, class: "space-y-6" do |form| %>
+
+  <div class="form-control">
+    <%= form.text_field :title, placeholder: "タイトルを入力してください", class: "input input-bordered w-full" %>
+  </div>
+
+  <div class="form-control">
+    <label class="label">カテゴリーを選択してください</label>
+    <div class="flex space-x-4">
+      <% Category.all.each do |category| %>
+        <label class="cursor-pointer label">
+          <%= form.radio_button :category_id, category.id, class: "radio" %>
+          <span class="ml-2 text-sm"><%= category.name %></span>
+        </label>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="form-control">
+    <label class="label">タグを選択してください</label>
+    <div class="flex flex-wrap space-x-4">
+      <% Tag.all.each do |tag| %>
+        <label class="cursor-pointer label">
+          <%= form.check_box :tag_ids, { multiple: true }, tag.id, nil, class: "checkbox" %>
+          <span class="ml-2 text-sm"><%= tag.name %></span>
+        </label>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="form-control">
+    <%= form.text_area :content, placeholder: "本文を入力してください", class: "textarea textarea-bordered w-full h-40" %>
+  </div>
+
+  <div class="form-control">
+    <button type="button" id="ai-correction-button" class="btn btn-primary w-full">AI校正をする</button>
+  </div>
+
+  <div class="form-control">
+    <%= form.file_field :image, class: "file-input file-input-bordered w-full" %>
+  </div>
+
+  <div class="form-control">
+    <%= form.label :reference_url, "関連URL (オプション)", class: "label" %>
+    <%= form.url_field :reference_url, placeholder: "http://example.com", class: "input input-bordered w-full" %>
+  </div>
+
+  <div class="form-control flex space-x-4">
+    <%= link_to "キャンセル", root_path, class: "btn btn-secondary flex-1" %>
+    <%= form.submit "下書き保存", name: "draft", class: "btn btn-outline flex-1" %>
+    <%= form.submit "投稿する", class: "btn btn-primary flex-1" %>
+  </div>
+<% end %>
+
+<script>
+  document.getElementById("ai-correction-button").addEventListener("click", function() {
+    // モーダルでAI校正結果を表示する処理をここに追加します
+    alert("AI校正を実行しました。");
+  });
+</script>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,11 +1,11 @@
 <div class="btm-nav btm-nav-lg">
 
-  <%= link_to "", class: "flex flex-col items-center btm-nav-item" do %>
+  <%= link_to posts_path, class: "flex flex-col items-center btm-nav-item" do %>
     <%= image_tag 'home_button.svg', alt: "Home", class: "h-5 w-5" %>
     <span class="btm-nav-label">投稿一覧</span>
   <% end %>
 
-  <%= link_to "", class: "flex flex-col items-center btm-nav-item active" do %>
+  <%= link_to new_post_path, class: "flex flex-col items-center btm-nav-item active" do %>
     <%= image_tag 'create_button.svg', alt: "Create", class: "h-5 w-5" %>
     <span class="btm-nav-label">投稿する</span>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
                sessions: "users/sessions"
              }
 
-  resources :posts, only: %i[index]
+  resources :posts, only: %i[index new]
 
   # Health check ルート（アップタイムモニタリング用）
   get "up" => "rails/health#show", as: :rails_health_check

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
                sessions: "users/sessions"
              }
 
-  resources :posts, only: %i[index new]
+  resources :posts, only: %i[index new create]
 
   # Health check ルート（アップタイムモニタリング用）
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20241102020037_create_posts.rb
+++ b/db/migrate/20241102020037_create_posts.rb
@@ -8,6 +8,7 @@ class CreatePosts < ActiveRecord::Migration[7.2]
       t.integer :status, null: false
       t.string :image
       t.text :ai_corrected_content
+      t.string :reference_url 
       t.timestamps
     end
   end

--- a/db/migrate/20241105032617_change_status_null_constraint_in_posts.rb
+++ b/db/migrate/20241105032617_change_status_null_constraint_in_posts.rb
@@ -1,0 +1,6 @@
+class ChangeStatusNullConstraintInPosts < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :posts, :status, true
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_02_080441) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_05_032617) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,9 +34,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_02_080441) do
     t.string "title", null: false
     t.text "content", null: false
     t.bigint "category_id", null: false
-    t.integer "status", null: false
+    t.integer "status"
     t.string "image"
     t.text "ai_corrected_content"
+    t.string "reference_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["category_id"], name: "index_posts_on_category_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,11 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+categories = [
+  "トレーニング", "栄養・食事", "ランニングギア",
+  "大会準備", "健康・怪我予防", "大会レポート"
+]
+
+categories.each do |name|
+  Category.find_or_create_by(name: name)
+end


### PR DESCRIPTION
### 概要
新規投稿ページを作成し、ユーザーが投稿を作成・保存できるようにしました。

### 行ったこと
* 新規投稿ページの作成 (new.html.erb)
フォームを追加し、タイトル、カテゴリー、本文、画像、関連URLの入力フィールドを作成。
投稿の保存機能を追加 (PostsController#create)
投稿データを受け取り、バリデーションを通過した場合に保存。
保存成功時に投稿一覧ページへリダイレクトし、フラッシュメッセージを表示。

*モデルのバリデーション追加 (Post)
タイトル、内容、カテゴリーの必須チェックを追加。

* 投稿一覧のビューを改善 (_post.html.erb)
投稿詳細の表示を見やすく改善。

* ルーティングの設定 (config/routes.rb)
投稿作成用のルートを追加。

* マイグレーションとシードデータの更新
ステータスカラムのnull制約を解除。
seeds.rb に標準タグとカテゴリー固有タグを追加。

### 備考
投稿のステータス機能は未実装のため、現時点では利用していません。
タグについては別途作成します。

関連ISSUE
closed  #8 
