### PR TITLE
rails db:migration削除

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,4 +3,3 @@ set -o errexit
 bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
-bundle exec rails db:migrate


### PR DESCRIPTION
### 概要
本番環境において自動でdb:migrateとdb:seedを走らせるために、render.comの設定でこれらをPre-Deploy Commandに追加した。そのため、開発環境のbin/render-build.shのdb:migrateは重複するため削除した。