### PR TITLE
ユーザーテーブルにプロフィール関係のカラムを追加

### DIFF
--- a/db/migrate/20241114042649_add_profile_fields_to_users.rb
+++ b/db/migrate/20241114042649_add_profile_fields_to_users.rb
@@ -1,0 +1,15 @@
+class AddProfileFieldsToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :profile_image, :string unless column_exists?(:users, :profile_image)
+    add_column :users, :gender, :integer unless column_exists?(:users, :gender)
+    add_column :users, :age, :string unless column_exists?(:users, :age)
+    add_column :users, :running_goal, :string unless column_exists?(:users, :running_goal)
+    add_column :users, :running_specs, :string unless column_exists?(:users, :running_specs)
+    add_column :users, :instagram_url, :string unless column_exists?(:users, :instagram_url)
+    add_column :users, :twitter_url, :string unless column_exists?(:users, :twitter_url)
+    add_column :users, :facebook_url, :string unless column_exists?(:users, :facebook_url)
+    add_column :users, :reference_url1, :string unless column_exists?(:users, :reference_url1)
+    add_column :users, :reference_url2, :string unless column_exists?(:users, :reference_url2)
+    add_column :users, :bio, :text unless column_exists?(:users, :bio)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_10_064850) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_14_042649) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
### 概要
本番環境でユーザーテーブル内のprofile_image等のユーザープロフィールに関するカラムが存在しないことを確認したため、追加した。