### PR TITLE
Feature/#20 Kaminariを導入し、ページネーションを実装しました

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "rmagick", "~> 6.0", ">= 6.0.1"
 
 gem "ransack"
 
-gem 'kaminari'
+gem "kaminari"
 
 gem "rails-i18n"
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ gem "rmagick", "~> 6.0", ">= 6.0.1"
 
 gem "ransack"
 
+gem 'kaminari'
+
 gem "rails-i18n"
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.1", ">= 7.2.1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,18 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.7.4)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
     logger (1.6.1)
     loofah (2.23.1)
@@ -346,6 +358,7 @@ DEPENDENCIES
   faker
   jbuilder
   jsbundling-rails
+  kaminari
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.1, >= 7.2.1.2)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,7 +5,7 @@ class PostsController < ApplicationController
 
   def index
     @q = Post.ransack(params[:q])
-    @posts = @q.result(distinct: true).includes(:tags, :user, :category)# .page(params[:page])
+    @posts = @q.result(distinct: true).includes(:tags, :user, :category).page(params[:page]).per(6)
     @categories = Category.all
   end
 

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<span class="next">
+  <%= link_to_unless current_page.last?, "次へ", url, class: "join-item btn", rel: 'next', remote: true %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,1 @@
+<%= link_to page, url, class: "join-item btn #{'btn-active' if page.current?}", remote: true, rel: page.rel %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,15 @@
+<div class="join text-xs mt-8 mx-auto flex justify-center">
+  <%= paginator.render do -%>
+    <nav class="pagination" role="navigation" aria-label="pager" style="margin-top: 20px; margin-bottom: 20px;">
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| -%>
+        <% if page.display_tag? -%>
+          <%= page_tag page %>
+        <% end -%>
+      <% end -%>
+      <% unless current_page.out_of_range? %>
+        <%= next_page_tag unless current_page.last? %>
+      <% end %>
+    </nav>
+  <% end -%>
+</div>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<span class="prev">
+  <%= link_to_unless current_page.first?, "前へ", url, class: "join-item btn", rel: 'prev', remote: true %>  
+</span>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -38,3 +38,5 @@
     <% end %>
   </div>
 </div>
+
+<%= paginate @posts %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 5
+  config.window = 2
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end


### PR DESCRIPTION
### 概要
投稿一覧ページにページネーションを実装しました。
Kaminariを使用して、ページネーション機能を実現しています。

### 行ったこと
* Kaminariの導入
  * GemfileにKaminariを追加。
* Kaminariの設定ファイル作成
  * rails g kaminari:config を実行して、設定ファイルを生成。
* コントローラーの変更
  * PostsController の index アクションで、Post モデルにページネーションを追加しました。
* ビューの変更
  * 投稿一覧ページ (index.html.erb) にページネーションの表示を追加。
  * Tailwind CSS と Daisy UI を使用してスタイリング。
* カスタムビューの作成
  * rails g kaminari:views default を実行してビューを生成。
  * Daisy UI 用にページネーションのデザインをカスタマイズ。

### 関連ISSUE
Close #89 ページネーション機能の実装

### 備考
ページネーションの1ページあたりの表示件数は、6件に設定しています。
Daisy UI を活用したデザインのカスタマイズを行いました。