### PR TITLE
fix/レイアウトの修正: ヘッダーとフラッシュメッセージの重なり問題を解消

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,12 +18,12 @@
   </head>
 
   <body>
-  <%= render 'shared/flash_messages' %>
   <% if user_signed_in? %>
     <%= render 'shared/after_header_login' %>
   <% else %>
     <%= render 'shared/before_header_login' %>
   <% end %>
+  <%= render 'shared/flash_messages' %>
   <%= yield %>
   <%= render "shared/footer" %>
   </body>

--- a/app/views/shared/_after_header_login.html.erb
+++ b/app/views/shared/_after_header_login.html.erb
@@ -1,4 +1,4 @@
-<div class="navbar bg-base-100" style="position: fixed; top: 0; right: 0; z-index: 10000;">
+<div class="navbar bg-base-100">
   <div class="flex-1">
     <%= link_to 'RunBreeze', root_path, class: "btn btn-ghost text-xl" %>
   </div>

--- a/app/views/shared/_before_header_login.html.erb
+++ b/app/views/shared/_before_header_login.html.erb
@@ -1,4 +1,4 @@
-<div class="navbar bg-base-100" style="position: fixed; top: 0; right: 0; z-index: 10000;">
+<div class="navbar bg-base-100">
   <div class="flex-1">
     <%= link_to 'RunBreeze', root_path, class: "btn btn-ghost text-xl" %>
   </div>


### PR DESCRIPTION
### 概要
ヘッダーとフラッシュメッセージの重なり問題を解消した。

### 備考
上記解消の結果、ヘッダーの固定が解除されたため、別アプローチ方法を模索する必要があるため、ISSUEとしてあげる。