### PR TITLE
chore/Googleアナリティクスの導入

### DIFF
--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -1,0 +1,9 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-QKGG9XWYJ3"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-QKGG9XWYJ3');
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,11 @@
     <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module", defer: true %>
+
+    <%# Googleアナリティクス導入 %>
+    <% if Rails.env.production? %>
+      <%= render 'layouts/google_analytics' %>
+    <% end %>
   </head>
 
   <body>


### PR DESCRIPTION
## chore/Googleアナリティクスの導入

### 概要
GoogleアナリティクスをRailsアプリに導入しました。これにより、サイトのトラフィックやユーザーの行動データを計測できるようになります。

---

### 行ったこと
- `app/views/layouts/application.html.erb` にGoogleアナリティクス用のコードを組み込む条件分岐を追加。
  - 本番環境（`Rails.env.production?`）でのみ読み込む設定を追加。
- `_google_analytics.html.erb` パーシャルを作成。
  - Googleタグ（gtag.js）の埋め込みコードを記述。
- 動作確認済み（ブラウザのデベロッパーツールでGoogleタグが読み込まれていることを確認）。

---

### 関連ISSUE
- Close #26 

---

### 備考
- 開発環境やテスト環境ではGoogleアナリティクスが動作しないようにしています。
- 将来的にGoogleタグマネージャーへの移行も検討可能です。
