### PR TITLE
Chore/プライバシーポリシーの追加

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,7 @@
 class StaticPagesController < ApplicationController
   def top
   end
+
+  def privacy_policy
+  end
 end

--- a/app/views/shared/_after_header_login.html.erb
+++ b/app/views/shared/_after_header_login.html.erb
@@ -16,7 +16,7 @@
         <li><%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete, turbo_confirm: "ログアウトしてもよろしいですか？" }, class: "btn btn-ghost w-full text-left" %></li>
         <hr>
         <li><%= link_to '利用規約', "", class: "btn btn-ghost w-full text-left" %></li>
-        <li><%= link_to 'プライバシーポリシー', "", class: "btn btn-ghost w-full text-left" %></li>
+        <li><%= link_to 'プライバシーポリシー', privacy_policy_path, class: "btn btn-ghost w-full text-left" %></li>
         <li><%= link_to 'お問い合わせ', "https://forms.gle/YMuTma5zqtiNunGaA", class: "btn btn-ghost w-full text-left" %></li>
         <hr>
         <li class="text-center text-xs mt-2">&copy; 2024 RunBreeze</li>

--- a/app/views/shared/_before_header_login.html.erb
+++ b/app/views/shared/_before_header_login.html.erb
@@ -14,7 +14,7 @@
         <li><%= link_to '新規登録', new_user_registration_path, class: "btn btn-ghost" %></li>
         <hr>
         <li><%= link_to '利用規約', "", class: "btn btn-ghost w-full text-left" %></li>
-        <li><%= link_to 'プライバシーポリシー', "", class: "btn btn-ghost w-full text-left" %></li>
+        <li><%= link_to 'プライバシーポリシー', privacy_policy_path, class: "btn btn-ghost w-full text-left" %></li>
         <li><%= link_to 'お問い合わせ', "https://forms.gle/YMuTma5zqtiNunGaA", class: "btn btn-ghost w-full text-left" %></li>
         <hr>
         <li class="text-center text-xs mt-2">&copy; 2024 RunBreeze</li>

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -1,0 +1,75 @@
+<div class="container mx-auto max-w-3xl px-4 py-8">
+  <!-- タイトル -->
+  <div class="text-center mb-8">
+    <h1 class="text-2xl font-bold border-b-2 border-gray-300 inline-block pb-2">プライバシーポリシー</h1>
+  </div>
+
+  <!-- お客様から取得する情報 -->
+  <section class="mb-6">
+    <h2 class="text-xl font-semibold mb-4">お客様から取得する情報</h2>
+    <p>当社は、お客様から以下の情報を取得します。</p>
+    <ul class="list-disc ml-6 mt-2">
+      <li><span class="mr-1">・</span>氏名(ニックネームやペンネームも含む)</li>
+      <li><span class="mr-1">・</span>メールアドレス</li>
+      <li><span class="mr-1">・</span>写真や動画</li>
+      <li><span class="mr-1">・</span>外部サービスでお客様が利用するID、その他外部サービスのプライバシー設定によりお客様が連携先に開示を認めた情報</li>
+      <li><span class="mr-1">・</span>Cookie(クッキー)を用いて生成された識別情報</li>
+      <li><span class="mr-1">・</span>OSが生成するID、端末の種類、端末識別子等のお客様が利用するOSや端末に関する情報</li>
+      <li><span class="mr-1">・</span>当社ウェブサイトの滞在時間、入力履歴、購買履歴等の当社ウェブサイトにおけるお客様の行動履歴</li>
+      <li><span class="mr-1">・</span>当社アプリの起動時間、入力履歴、購買履歴等の当社アプリの利用履歴</li>
+    </ul>
+  </section>
+
+  <!-- お客様の情報を利用する目的 -->
+  <section class="mb-6">
+    <h2 class="text-xl font-semibold mb-4">お客様の情報を利用する目的</h2>
+    <p>当社は、お客様から取得した情報を、以下の目的のために利用します。</p>
+    <ul class="list-disc ml-6 mt-2">
+      <li><span class="mr-1">・</span>当社サービスに関する登録の受付、お客様の本人確認、認証のため</li>
+      <li><span class="mr-1">・</span>お客様の当社サービスの利用履歴を管理するため</li>
+      <li><span class="mr-1">・</span>当社サービスにおけるお客様の行動履歴を分析し、当社サービスの維持改善に役立てるため</li>
+      <li><span class="mr-1">・</span>当社のサービスに関するご案内をするため</li>
+      <li><span class="mr-1">・</span>お客様からのお問い合わせに対応するため</li>
+      <li><span class="mr-1">・</span>当社の規約や法令に違反する行為に対応するため</li>
+      <li><span class="mr-1">・</span>当社サービスの変更、提供中止、終了、契約解除をご連絡するため</li>
+      <li><span class="mr-1">・</span>当社規約の変更等を通知するため</li>
+      <li><span class="mr-1">・</span>以上の他、当社サービスの提供、維持、保護及び改善のため</li>
+    </ul>
+  </section>
+
+  <!-- 安全管理のために講じた措置 -->
+  <section class="mb-6">
+    <h2 class="text-xl font-semibold mb-4">安全管理のために講じた措置</h2>
+    <p>当社が、お客様から取得した情報に関して安全管理のために講じた措置につきましては、末尾記載のお問い合わせ先にご連絡をいただきましたら、法令の定めに従い個別にご回答させていただきます。</p>
+  </section>
+
+  <!-- 第三者提供 -->
+  <section class="mb-6">
+    <h2 class="text-xl font-semibold mb-4">第三者提供</h2>
+    <p>当社は、お客様から取得する情報のうち、個人データ（個人情報保護法第16条第3項）に該当するものついては、あらかじめお客様の同意を得ずに、第三者（日本国外にある者を含みます。）に提供しません。但し、次の場合は除きます。</p>
+    <ul class="list-disc ml-6 mt-2">
+      <li><span class="mr-1">・</span>個人データの取扱いを外部に委託する場合</li>
+      <li><span class="mr-1">・</span>当社や当社サービスが買収された場合</li>
+      <li><span class="mr-1">・</span>事業パートナーと共同利用する場合（具体的な共同利用がある場合は、その内容を別途公表します。）</li>
+      <li><span class="mr-1">・</span>その他、法律によって合法的に第三者提供が許されている場合</li>
+    </ul>
+  </section>
+
+  <!-- アクセス解析ツール -->
+  <section class="mb-6">
+    <h2 class="text-xl font-semibold mb-4">アクセス解析ツール</h2>
+    <p>当社は、お客様のアクセス解析のために、「Googleアナリティクス」を利用しています。Googleアナリティクスは、トラフィックデータの収集のためにCookieを使用しています。トラフィックデータは匿名で収集されており、個人を特定するものではありません。Cookieを無効にすれば、これらの情報の収集を拒否することができます。詳しくはお使いのブラウザの設定をご確認ください。</p>
+    <p class="mt-2">Googleアナリティクスについて、詳しくは<a href="https://marketingplatform.google.com/about/analytics/terms/jp/" class="text-blue-500 underline" target="_blank" rel="noopener noreferrer">こちら</a>からご確認ください。</p>
+  </section>
+
+  <!-- お問い合わせ -->
+  <section class="mb-6">
+    <h2 class="text-xl font-semibold mb-4">お問い合わせ</h2>
+    <p>お客様の情報の開示、情報の訂正、利用停止、削除をご希望の場合は、<a href="https://forms.gle/YMuTma5zqtiNunGaA" class="text-blue-500 underline" target="_blank" rel="noopener noreferrer">お問い合わせフォーム</a>からご連絡ください。</p>
+  </section>
+
+  <!-- 制定日 -->
+  <footer style="margin-bottom: 8rem; text-align: right; color: #6b7280; font-size: 0.875rem; padding-top: 1rem;">
+  2024年12月01日 制定
+</footer>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,4 +38,6 @@ Rails.application.routes.draw do
   # PWA サポート用の動的ルート
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+
+  get "privacy_policy" => "static_pages#privacy_policy", as: :privacy_policy
 end


### PR DESCRIPTION
### 概要
プライバシーポリシーページの追加に関する対応を行いました。

### 行ったこと
- プライバシーポリシーページのビューを追加
- StaticPagesControllerに`privacy_policy`アクションを追加
- `config/routes.rb` にプライバシーポリシーページへのルートを追加
- ヘッダー（ログイン前/ログイン後）にプライバシーポリシーページへのリンクを追加

### 関連ISSUE
closed #29 

### 備考
特になし