### PR TITLE
Chore/利用規約の追加

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -4,4 +4,7 @@ class StaticPagesController < ApplicationController
 
   def privacy_policy
   end
+
+  def terms_of_service
+  end
 end

--- a/app/views/shared/_after_header_login.html.erb
+++ b/app/views/shared/_after_header_login.html.erb
@@ -15,7 +15,7 @@
         <hr>
         <li><%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete, turbo_confirm: "ログアウトしてもよろしいですか？" }, class: "btn btn-ghost w-full text-left" %></li>
         <hr>
-        <li><%= link_to '利用規約', "", class: "btn btn-ghost w-full text-left" %></li>
+        <li><%= link_to '利用規約', terms_of_service_path, class: "btn btn-ghost w-full text-left" %></li>
         <li><%= link_to 'プライバシーポリシー', privacy_policy_path, class: "btn btn-ghost w-full text-left" %></li>
         <li><%= link_to 'お問い合わせ', "https://forms.gle/YMuTma5zqtiNunGaA", class: "btn btn-ghost w-full text-left" %></li>
         <hr>

--- a/app/views/shared/_before_header_login.html.erb
+++ b/app/views/shared/_before_header_login.html.erb
@@ -13,7 +13,7 @@
       <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
         <li><%= link_to '新規登録', new_user_registration_path, class: "btn btn-ghost" %></li>
         <hr>
-        <li><%= link_to '利用規約', "", class: "btn btn-ghost w-full text-left" %></li>
+        <li><%= link_to '利用規約', terms_of_service_path, class: "btn btn-ghost w-full text-left" %></li>
         <li><%= link_to 'プライバシーポリシー', privacy_policy_path, class: "btn btn-ghost w-full text-left" %></li>
         <li><%= link_to 'お問い合わせ', "https://forms.gle/YMuTma5zqtiNunGaA", class: "btn btn-ghost w-full text-left" %></li>
         <hr>

--- a/app/views/static_pages/terms_of_service.erb
+++ b/app/views/static_pages/terms_of_service.erb
@@ -1,0 +1,60 @@
+<div class="container mx-auto max-w-3xl px-4 py-8">
+  <!-- タイトル -->
+  <div class="text-center mb-8">
+    <h1 class="text-2xl font-bold">利用規約</h1>
+  </div>
+
+  <!-- 利用規約本文 -->
+  <section class="mb-6">
+    <h2 class="text-xl font-semibold mb-4">本規約への同意</h2>
+    <p>ユーザーは、本サービスを利用することによって、本規約に有効かつ取り消し不能な同意をしたものとみなされます。<br>
+    本規約に同意しないユーザーは、本サービスをご利用いただけません。</p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-xl font-semibold mb-4">利用登録</h2>
+    <p>本サービスの利用を希望する方は、本規約に同意の上、当社の定める方法によって利用登録を申請し、当社がこれを承認することによって、本サービスの利用登録をすることができます。</p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-xl font-semibold mb-4">登録拒否</h2>
+    <p>本サービスは、以下のいずれかの事由があると判断した場合、利用登録の申請を承認しないことがあります。<br>
+    本サービスは登録拒否の理由について一切の開示義務を負いません。</p>
+    <ul class="list-disc ml-6 mt-2">
+      <li>虚偽の事項を届け出た場合</li>
+      <li>本規約に違反したことがある者からの申請である場合</li>
+      <li>その他、当社が利用登録を相当でないと判断した場合</li>
+    </ul>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-xl font-semibold mb-4">未成年による利用</h2>
+    <p>ユーザーが未成年である場合には、法定代理人の同意を得た上で、本サービスを利用してください。<br>
+    法定代理人の同意を得ずに本サービスのご利用を開始したユーザーが成年に達した場合、未成年者であった間の利用行為を追認したものとみなします。</p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-xl font-semibold mb-4">ログイン情報の管理</h2>
+    <p>ユーザーは、自己の責任において、本サービスのログイン情報を適切に管理するものとします。<br>
+    ユーザーは、いかなる場合にも、ログイン情報を第三者に譲渡または貸与し、もしくは第三者と共用することはできません。<br>
+    本サービスは、ログイン情報が第三者によって使用されたことによって生じた損害につき、当社に故意又は重大な過失がある場合を除き、一切の責任を負いません。</p>
+  </section>
+
+  <!-- 以下、必要に応じて追加 -->
+  <!-- セクション例 -->
+  <section class="mb-6">
+    <h2 class="text-xl font-semibold mb-4">禁止事項</h2>
+    <p>ユーザーは、本サービスの利用にあたり、以下の行為をしてはなりません。</p>
+    <ul class="list-disc ml-6 mt-2">
+      <li>法令、裁判所の判決、決定若しくは命令に違反する行為</li>
+      <li>犯罪行為に関連する行為</li>
+      <li>他のユーザーまたは第三者に不利益、損害、不快感を与える行為</li>
+      <li>その他、当社が不適切と判断する行為</li>
+    </ul>
+  </section>
+
+  <!-- 制定日 -->
+  <footer style="margin-bottom: 8rem; text-align: right; color: #6b7280; font-size: 0.875rem; padding-top: 1rem;">
+    2024年12月01日 制定
+  </footer>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,4 +40,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   get "privacy_policy" => "static_pages#privacy_policy", as: :privacy_policy
+  get "terms_of_service" => "static_pages#terms_of_service", as: :terms_of_service
 end


### PR DESCRIPTION
### 概要
利用規約ページを追加しました。

### 行ったこと
- `StaticPagesController` に `terms_of_service` アクションを追加
- `config/routes.rb` に利用規約ページへのルートを追加
- ヘッダーのログイン前後に利用規約リンクを追加
  - `app/views/shared/_after_header_login.html.erb`
  - `app/views/shared/_before_header_login.html.erb`
- 利用規約のビュー (`terms_of_service.erb`) を作成

### 関連ISSUE
利用規約のページ追加に関するタスク  
Close #150 