### PR TITLE
Feature/#29 ユーザー詳細ページの作成

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: [ :show ]
 
   def mypage
     @user = current_user
@@ -32,6 +32,14 @@ class UsersController < ApplicationController
       flash.now[:alert] = "パスワードの更新に失敗しました。"
       render :edit_password, status: :unprocessable_entity
     end
+  end
+
+  # 他のユーザーのプロフィールを表示
+  def show
+    @user = User.find(params[:id])
+    @posts = @user.posts.order(created_at: :desc).page(params[:page]).per(6)
+  rescue ActiveRecord::RecordNotFound
+    redirect_to posts_path, alert: "ユーザーが見つかりません"
   end
 
   private

--- a/app/views/posts/_post_card.html.erb
+++ b/app/views/posts/_post_card.html.erb
@@ -1,55 +1,65 @@
-<%= link_to post_path(post), class: "block" do %>
-  <div class="card bg-base-100 shadow-xl flex flex-row p-4">
-    <!-- 画像とカテゴリー -->
-    <div class="w-1/4 relative mr-4">
-      <% if post.post_image.present? %>
+<!-- app/views/posts/_post_card.html.erb -->
+
+<div class="card bg-base-100 shadow-xl flex flex-row p-4">
+  <!-- 画像とカテゴリー -->
+  <div class="w-1/4 relative mr-4">
+    <% if post.post_image.present? %>
+      <%= link_to post_path(post) do %>
         <%= image_tag(post.post_image.url, alt: post.title, class: "w-full h-full object-cover aspect-square") %>
-      <% else %>
+      <% end %>
+    <% else %>
+      <%= link_to post_path(post) do %>
         <%= image_tag("default_post_image.jpg", alt: post.title, class: "w-full h-full object-cover aspect-square") %>
       <% end %>
+    <% end %>
 
-      <% if post.category.present? %>
-        <div class="absolute top-0 left-0 bg-gray-800 text-white text-xs px-2 py-1 rounded-bl-lg">
-          <%= post.category.name %>
-        </div>
+    <% if post.category.present? %>
+      <div class="absolute top-0 left-0 bg-gray-800 text-white text-xs px-2 py-1 rounded-bl-lg">
+        <%= post.category.name %>
+      </div>
+    <% end %>
+  </div>
+
+  <!-- コンテンツ部分 -->
+  <div class="w-3/4">
+    <!-- タグ -->
+    <div class="flex flex-wrap space-x-2 mb-1">
+      <% post.tags.each do |tag| %>
+        <span class="bg-gray-200 text-gray-700 text-xs px-2 py-1 rounded-full">#<%= tag.name %></span>
       <% end %>
     </div>
 
-    <!-- コンテンツ部分 -->
-    <div class="w-3/4">
-      <!-- タグ -->
-      <div class="flex flex-wrap space-x-2 mb-1">
-        <% post.tags.each do |tag| %>
-          <span class="bg-gray-200 text-gray-700 text-xs px-2 py-1 rounded-full">#<%= tag.name %></span>
-        <% end %>
-      </div>
+    <!-- タイトル -->
+    <h2 class="text-lg font-bold">
+      <%= link_to post.title, post_path(post), class: "text-gray-800 hover:underline" %>
+    </h2>
 
-      <!-- タイトル -->
-      <h2 class="text-lg font-bold"><%= post.title %></h2>
+    <!-- 内容（概要表示） -->
+    <p class="text-sm text-gray-600 line-clamp-2 mt-1">
+      <%= link_to truncate(post.content, length: 100), post_path(post), class: "text-gray-600 hover:text-gray-800 hover:underline" %>
+    </p>
 
-      <!-- 内容（概要表示） -->
-      <p class="text-sm text-gray-600 line-clamp-2 mt-1"><%= truncate(post.content, length: 100) %></p>
-
-      <!-- ユーザー情報とアクションボタン -->
-      <div class="flex items-center justify-between mt-2">
-        <!-- ユーザーアイコンと名前 -->
-        <div class="flex items-center">
+    <!-- ユーザー情報とアクションボタン -->
+    <div class="flex items-center justify-between mt-2">
+      <!-- ユーザーアイコンと名前 -->
+      <div class="flex items-center">
+        <%= link_to user_profile_path(post.user), class: "flex items-center space-x-2" do %>
           <% if post.user.profile_image.present? %>
             <%= image_tag(post.user.profile_image.url, alt: post.user.username, class: "w-8 h-8 rounded-full") %>
           <% else %>
             <%= image_tag("default_profile_image.svg", alt: post.user.username, class: "w-8 h-8 rounded-full") %>
           <% end %>
           <span class="text-sm text-gray-700"><%= post.user.username %></span>
-        </div>
+        <% end %>
+      </div>
 
-        <!-- アクションボタン（いいね・ブックマーク） -->
-        <div class="flex items-center space-x-4">
-          <!-- いいねボタン -->
-          <%= render 'likes/like_buttons', post: post %>
-          <!-- ブックマークボタン -->
-          <%= render 'bookmarks/bookmark_buttons', post: post %>
-        </div>
+      <!-- アクションボタン（いいね・ブックマーク） -->
+      <div class="flex items-center space-x-4">
+        <!-- いいねボタン -->
+        <%= render 'likes/like_buttons', post: post %>
+        <!-- ブックマークボタン -->
+        <%= render 'bookmarks/bookmark_buttons', post: post %>
       </div>
     </div>
   </div>
-<% end %>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,15 +1,17 @@
 <div class="container mx-auto px-4 py-8">
   <!-- ユーザー情報 -->
   <div class="flex items-center mb-4">
-    <% if @post.user.profile_image.present? %>
-      <%= image_tag @post.user.profile_image.url, alt: @post.user.username, class: "w-10 h-10 rounded-full mr-2" %>
-    <% else %>
-      <%= image_tag "default_profile_image.svg", alt: @post.user.username, class: "w-10 h-10 rounded-full mr-2" %>
+    <%= link_to user_profile_path(@post.user), class: "flex items-center" do %>
+      <% if @post.user.profile_image.present? %>
+        <%= image_tag @post.user.profile_image.url, alt: @post.user.username, class: "w-10 h-10 rounded-full mr-2" %>
+      <% else %>
+        <%= image_tag "default_profile_image.svg", alt: @post.user.username, class: "w-10 h-10 rounded-full mr-2" %>
+      <% end %>
+      <div>
+        <p class="text-sm font-semibold"><%= @post.user.username %></p>
+        <p class="text-xs text-gray-500"><%= @post.created_at.strftime("%Y年%m月%d日") %></p>
+      </div>
     <% end %>
-    <div>
-      <p class="text-sm font-semibold"><%= @post.user.username %></p>
-      <p class="text-xs text-gray-500"><%= @post.created_at.strftime("%Y年%m月%d日") %></p>
-    </div>
   </div>
 
   <!-- 編集・削除リンク -->
@@ -82,15 +84,15 @@
     <% if @comments.any? %>
       <% @comments.each do |comment| %>
         <div class="flex items-center mb-2">
-          <% if comment.user.profile_image.present? %>
-            <%= image_tag comment.user.profile_image.url, alt: comment.user.username, class: "w-6 h-6 rounded-full mr-2" %>
-          <% else %>
-            <%= image_tag "default_profile_image.svg", alt: comment.user.username, class: "w-6 h-6 rounded-full mr-2" %>
-          <% end %>
-          <div>
+          <%= link_to user_profile_path(comment.user), class: "flex items-center" do %>
+            <% if comment.user.profile_image.present? %>
+              <%= image_tag comment.user.profile_image.url, alt: comment.user.username, class: "w-6 h-6 rounded-full mr-2" %>
+            <% else %>
+              <%= image_tag "default_profile_image.svg", alt: comment.user.username, class: "w-6 h-6 rounded-full mr-2" %>
+            <% end %>
             <span class="font-semibold"><%= comment.user.username %>:</span>
-            <span><%= comment.content %></span>
-          </div>
+          <% end %>
+          <span><%= comment.content %></span>
         </div>
       <% end %>
     <% else %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,49 @@
+<div class="max-w-4xl mx-auto bg-white shadow-md rounded-lg p-8">
+
+  <div class="flex flex-col items-center" style= "padding-bottom: 30px;">
+    <% if @user.profile_image.present? %>
+      <%= image_tag @user.profile_image.url, 
+        alt: @user.username, 
+        style: "border-radius: 50%; width: 8rem; height: 8rem; object-fit: cover; margin-bottom: 1rem;" %>
+    <% else %>
+      <%= image_tag "default_profile_image.svg", 
+        alt: @user.username, 
+        style: "border-radius: 50%; width: 8rem; height: 8rem; object-fit: cover; margin-bottom: 1rem;" %>
+    <% end %>
+
+    <h2 class="text-2xl font-semibold mb-2"><%= @user.username %></h2>
+
+    <p class="text-gray-700 mb-1">
+      <strong>ランニングの目的:</strong>
+      <%= @user.running_goal.present? ? @user.running_goal : '未設定' %>
+    </p>
+
+    <p class="text-gray-700 mb-1">
+      <strong>ランニングの目標:</strong>
+      <%= @user.running_specs.present? ? @user.running_specs : '未設定' %>
+    </p>
+
+    <p class="text-gray-700 mb-4 text-center">
+      <strong>自己紹介:</strong><br>
+      <%= @user.bio.present? ? simple_format(@user.bio) : '未設定' %>
+    </p>
+
+    <% if @user.reference_url1.present? %>
+      <a href="<%= @user.reference_url1 %>" target="_blank" class="text-blue-500 hover:underline mb-4">
+        SNSやブログ等のリンクはこちら
+      </a>
+    <% end %>
+  </div>
+</div>
+
+<div class="max-w-4xl mx-auto mt-2">
+  <% if @posts.any? %>
+    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+      <% @posts.each do |post| %>
+        <%= render 'posts/post_card', post: post %>
+      <% end %>
+    </div>
+  <% else %>
+    <p class="text-gray-600">まだ投稿がありません。</p>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
     get "edit_password" => "users#edit_password", as: :edit_password
     patch "update_password" => "users#update_password", as: :update_password
 
+    get "users/:id" => "users#show", as: :user_profile
+
   resources :posts do
     resources :comments, only: %i[create], shallow: true
     collection do


### PR DESCRIPTION
## 概要
他のユーザーの詳細ページを表示する機能を実装しました。ユーザーのプロフィール情報とその投稿一覧を閲覧できるようにし、投稿カードや投稿詳細ページ、コメント欄のユーザー情報から遷移できるリンクを追加しました。

## 行ったこと
- **ルーティングの追加**
  - `config/routes.rb` にユーザー詳細ページへのルートを追加
    - `get "users/:id", to: "users#show", as: :user_profile`
- **コントローラーの修正**
  - `UsersController` に `show` アクションを追加
  - ユーザー情報とその投稿を取得してビューに渡す処理を実装
- **投稿カードの修正**
  - 投稿カード内のユーザーアイコン・名前をユーザー詳細ページへのリンクに変更
  - 投稿内容に投稿詳細ページへのリンクを追加
- **投稿詳細ページの修正**
  - 投稿詳細ページ内のユーザーアイコン・名前をユーザー詳細ページへのリンクに変更
- **ユーザー詳細ページの作成**
  - ユーザーのプロフィール情報と投稿一覧を表示するビューを新規作成

## 関連ISSUE
- closed #115

## 備考
- ユーザー詳細ページでは「プロフィールを編集」「パスワードを変更」ボタンを非表示にしています。
- 存在しないユーザーへのアクセス時にはトップページにリダイレクトし、エラーメッセージを表示します。
