### PR TITLE
Feature/#31 既存ユーザーのgoogle認証対応およびフラッシュメッセージの表示

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,9 +1,4 @@
-# frozen_string_literal: true
-
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  # You should configure your model like this:
-  # devise :omniauthable, omniauth_providers: [:twitter]
-  # app/controllers/users/omniauth_callbacks_controller.rb
   def google_oauth2
     @user = User.from_omniauth(request.env["omniauth.auth"])
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,9 +13,9 @@ class User < ApplicationRecord
 
   validates :password, length: { minimum: 4 }, if: -> { new_record? || changes[:encrypted_password] }
 
-  validates :password_confirmation, presence: true, if: -> { password.present? } 
-  
-  validates :running_goal, inclusion: { in: ["ダイエット", "マラソン完走", "健康維持", "ストレス解消"]}, allow_blank: true
+  validates :password_confirmation, presence: true, if: -> { password.present? }
+
+  validates :running_goal, inclusion: { in: [ "ダイエット", "マラソン完走", "健康維持", "ストレス解消" ] }, allow_blank: true
 
   validates :running_specs, length: { maximum: 255 }, allow_blank: true
 
@@ -72,14 +72,14 @@ class User < ApplicationRecord
 
     if user
       # 既存のユーザーが見つかった場合、そのユーザーを返す
-      return user
+      user
     else
       # email でユーザーを検索
       user = find_by(email: auth.info.email)
       if user
         # 既存のユーザーに provider と uid を関連付けて保存
         user.update(provider: auth.provider, uid: auth.uid)
-        return user
+        user
       else
         # ユーザー名のユニーク性を確保
         base_username = auth.info.name.parameterize

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,19 +1,32 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable,
-         :omniauthable, omniauth_providers: %i[google_oauth2]
+  :recoverable, :rememberable, :validatable,
+  :omniauthable, omniauth_providers: %i[google_oauth2]
 
-  validates :username, presence: true, uniqueness: { case_sensitive: false }, length: { minimum: 3, maximum: 25 }
-  validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
-  validates :running_goal, inclusion: { in: [ "ダイエット", "マラソン完走", "健康維持", "ストレス解消" ], message: "%{value} は無効です" }, allow_blank: true
+  validates :username, presence: true,
+                       uniqueness: { case_sensitive: false },
+                       length: { minimum: 3, maximum: 25 }
+
+  validates :email, presence: true,
+                    uniqueness: true,
+                    format: { with: URI::MailTo::EMAIL_REGEXP }
+
+  validates :password, length: { minimum: 4 }, if: -> { new_record? || changes[:encrypted_password] }
+
+  validates :password_confirmation, presence: true, if: -> { password.present? } 
+  
+  validates :running_goal, inclusion: { in: ["ダイエット", "マラソン完走", "健康維持", "ストレス解消"]}, allow_blank: true
+
   validates :running_specs, length: { maximum: 255 }, allow_blank: true
-  validates :reference_url1, format: { with: URI::DEFAULT_PARSER.make_regexp, message: "有効なURLを入力してください" }, allow_blank: true
+
+  validates :reference_url1, format: { with: URI::DEFAULT_PARSER.make_regexp }, allow_blank: true
+
   validates :bio, length: { maximum: 200 }, allow_blank: true
+
+  # プロフィール画像アップロード
   mount_uploader :profile_image, ProfileImageUploader
 
-  # Userが削除されたときに関連するPostも削除される
+  # 関連付け
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :bookmarks, dependent: :destroy
@@ -26,6 +39,7 @@ class User < ApplicationRecord
     %w[username]
   end
 
+  # ブックマーク機能
   def bookmark(post)
     bookmark_posts << post
   end
@@ -38,6 +52,7 @@ class User < ApplicationRecord
     bookmark_posts.include?(post)
   end
 
+  # いいね機能
   def like(post)
     like_posts << post
   end
@@ -50,11 +65,40 @@ class User < ApplicationRecord
     like_posts.include?(post)
   end
 
+  # OmniAuthからのユーザー取得または作成
   def self.from_omniauth(auth)
-    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
-      user.email = auth.info.email
-      user.password = Devise.friendly_token[0, 20]
-      user.username = auth.info.name
+    # まず provider と uid でユーザーを検索
+    user = find_by(provider: auth.provider, uid: auth.uid)
+
+    if user
+      # 既存のユーザーが見つかった場合、そのユーザーを返す
+      return user
+    else
+      # email でユーザーを検索
+      user = find_by(email: auth.info.email)
+      if user
+        # 既存のユーザーに provider と uid を関連付けて保存
+        user.update(provider: auth.provider, uid: auth.uid)
+        return user
+      else
+        # ユーザー名のユニーク性を確保
+        base_username = auth.info.name.parameterize
+        unique_username = base_username
+        counter = 1
+        while User.exists?(username: unique_username)
+          unique_username = "#{base_username}#{counter}"
+          counter += 1
+        end
+
+        # 新規ユーザーを作成
+        create(
+          email: auth.info.email,
+          username: unique_username,
+          password: Devise.friendly_token[0, 20],
+          provider: auth.provider,
+          uid: auth.uid,
+        )
+      end
     end
   end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,5 +1,3 @@
-<!-- app/views/devise/registrations/new.html.erb -->
-
 <div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
   <div class="max-w-md w-full space-y-8">
     <!-- 新規登録タイトル -->
@@ -10,7 +8,7 @@
     </div>
 
     <!-- エラーメッセージの表示 -->
-    <%= devise_error_messages! %>
+    <%= render "shared/error_messages", resource: resource %>
 
     <!-- 新規登録フォーム -->
     <%= form_with(model: resource, as: resource_name, url: registration_path(resource_name), local: true) do |f| %>
@@ -60,9 +58,9 @@
 
     <!-- Googleアカウントで新規登録ボタン -->
     <div class="oauth-buttons mt-4 flex justify-center">
-    <%= button_to user_google_oauth2_omniauth_authorize_path, data: { turbo: false }, class: "btn btn-primary w-full flex items-center justify-center" do %>
-      <span class="text-gray-100 font-semibold">Googleでログイン</span>
-    <% end %> 
+      <%= button_to user_google_oauth2_omniauth_authorize_path, data: { turbo: false }, class: "btn btn-primary w-full flex items-center justify-center" do %>
+        <span class="text-gray-100 font-semibold">Googleでログイン</span>
+      <% end %> 
     </div>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,3 @@
-<!-- app/views/devise/sessions/new.html.erb -->
-
 <div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
   <div class="max-w-md w-full space-y-8">
     <!-- ログインタイトル -->
@@ -9,8 +7,8 @@
       </h2>
     </div>
 
-    <!-- エラーメッセージ -->
-    <%= devise_error_messages! %>
+    <!-- エラーメッセージの表示 -->
+    <%= render "shared/error_messages", resource: resource %>
 
     <!-- ログインフォーム -->
     <%= form_with(model: resource, as: resource_name, url: session_path(resource_name), local: true) do |f| %>
@@ -53,9 +51,9 @@
 
     <!-- Googleログインボタン -->
     <div class="oauth-buttons mt-4 flex justify-center">
-    <%= button_to user_google_oauth2_omniauth_authorize_path, data: { turbo: false }, class: "btn btn-primary w-full flex items-center justify-center" do %>
-      <span class="text-gray-100 font-semibold">Googleでログイン</span>
-    <% end %> 
+      <%= button_to user_google_oauth2_omniauth_authorize_path, data: { turbo: false }, class: "btn btn-primary w-full flex items-center justify-center" do %>
+        <span class="text-gray-100 font-semibold">Googleでログイン</span>
+      <% end %> 
     </div>
   </div>
 </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" data-turbo-cache="false">
+    <ul class="list-disc list-inside text-sm text-red-600">
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,10 +1,20 @@
 ja:
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      blank: "を入力してください。"
+      taken: "は既に使用されています。"
+      invalid: "は有効な値ではありません。"
+      too_short: "は%{count}文字以上で入力してください。"
+      # 他のデフォルトメッセージも必要に応じて追加
+
   activerecord:
     models:
       user: ユーザー
     attributes:
       user:
         email: メールアドレス
-        name: ユーザー名
+        username: ユーザー名
         password: パスワード
         password_confirmation: パスワード確認
+        # 他の属性も必要に応じて追加

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,4 +1,22 @@
+# config/locales/devise.ja.yml
+
 ja:
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      not_saved: "ユーザーの保存に失敗しました。以下のエラーをご確認ください。"
+      record_invalid: "無効なレコードです。"
+
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              taken: "このメールアドレスは既に使用されています。"
+            username:
+              taken: "このユーザー名は既に使用されています。"
+
   devise:
     sessions:
       signed_in: "ログインしました"
@@ -14,13 +32,16 @@ ja:
       unauthenticated: "ログインしてください"
       invalid: "ログインできませんでした"
       not_saved: "アカウントが作成できませんでした"
-      not_found_in_database: "無効な%{authentication_keys}またはパスワードです。" 
+      not_found_in_database: "無効な%{authentication_keys}またはパスワードです。"
     errors:
       messages:
         not_saved:
           one: "1件のエラーがあります"
           other: "%{count}件のエラーがあります"
-          too_short: "は%{count}文字以上で入力してください"
+          too_short: "は%{count}文字以上で入力してください。"
     omniauth_callbacks:
-      success: "%{kind}アカウントからログインしました"
-      failure: "%{kind}アカウントからログインできませんでした"
+      failure: "%{kind}からの認証に失敗しました。"
+      success: "%{kind}アカウントでログインしました"
+
+  # 他の翻訳も必要に応じて追加
+

--- a/db/migrate/20241205054651_add_index_to_users_provider_and_uid.rb
+++ b/db/migrate/20241205054651_add_index_to_users_provider_and_uid.rb
@@ -1,5 +1,5 @@
 class AddIndexToUsersProviderAndUid < ActiveRecord::Migration[7.2]
   def change
-    add_index :users, [:provider, :uid], unique: true
+    add_index :users, [ :provider, :uid ], unique: true
   end
 end

--- a/db/migrate/20241205054651_add_index_to_users_provider_and_uid.rb
+++ b/db/migrate/20241205054651_add_index_to_users_provider_and_uid.rb
@@ -1,0 +1,5 @@
+class AddIndexToUsersProviderAndUid < ActiveRecord::Migration[7.2]
+  def change
+    add_index :users, [:provider, :uid], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_04_112733) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_05_054651) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -106,6 +106,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_04_112733) do
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end


### PR DESCRIPTION
### 概要

既存ユーザーがGoogle認証でログインできるように対応し、エラーメッセージおよびフラッシュメッセージの表示を改善しました。また、フォームのデザインを調整し、エラーメッセージの表示箇所を共通化しました。

### 行ったこと

1. **既存ユーザーのGoogle認証対応**
   - 既存ユーザーがGoogle認証でログインできるよう、`from_omniauth` メソッドを改善。
   - `provider` と `uid` にインデックスを追加してパフォーマンスを最適化。

2. **エラーメッセージの表示改善**
   - エラーメッセージを表示する部分テンプレート `shared/_error_messages.html.erb` を作成。
   - フォームで共通化して利用。
   - 翻訳ファイルでエラーメッセージを簡潔化。

3. **フラッシュメッセージの改善**
   - Deviseのフラッシュメッセージの翻訳を整理し、Google認証用のメッセージを追加。

4. **フォームデザインの調整**
   - 新規登録フォームおよびログインフォームのレイアウトを調整。
   - エラーメッセージの表示箇所を改善。

### 関連ISSUE
#156 