### PR TITLE
Feature/#33 パスワードリセット

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,8 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+
+  gem "letter_opener"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
       image_processing (~> 1.1)
       marcel (~> 1.0.0)
       ssrf_filter (~> 1.0)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -185,6 +187,11 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
+    launchy (3.0.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
     logger (1.6.1)
     loofah (2.23.1)
       crass (~> 1.0.2)
@@ -432,6 +439,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   kaminari
+  letter_opener
   omniauth
   omniauth-google-oauth2
   omniauth-rails_csrf_protection

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+protected
+
+  def after_resetting_password_path_for(resource)
+    new_user_session_path # ログインページにリダイレクト
+  end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,25 +1,25 @@
 # frozen_string_literal: true
 
 class Users::PasswordsController < Devise::PasswordsController
-  # GET /resource/password/new
-  # def new
-  #   super
-  # end
+# GET /resource/password/new
+# def new
+#   super
+# end
 
-  # POST /resource/password
-  # def create
-  #   super
-  # end
+# POST /resource/password
+# def create
+#   super
+# end
 
-  # GET /resource/password/edit?reset_password_token=abcdef
-  # def edit
-  #   super
-  # end
+# GET /resource/password/edit?reset_password_token=abcdef
+# def edit
+#   super
+# end
 
-  # PUT /resource/password
-  # def update
-  #   super
-  # end
+# PUT /resource/password
+# def update
+#   super
+# end
 
 protected
 

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -7,7 +7,7 @@
   <body>
     <h1>RunBreeze</h1>
     <p>以下のリンクをクリックして、パスワードをリセットしてください。</p>
-    <p><%= link_to 'パスワードをリセット', edit_password_url(resource, reset_password_token: @token) %></p>
+    <%= link_to 'パスワードをリセット', edit_password_url(@resource, reset_password_token: @token) %>
     <p>このリンクは30分以内に有効です。</p>
     <p>もし心当たりがない場合は、このメールを無視してください。</p>
   </body>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,14 +1,28 @@
-<h2 class="text-xl font-bold text-center mb-6">パスワードをお忘れですか？</h2>
-
-<%= form_with(model: resource, as: resource_name, url: password_path(resource_name)) do |f| %>
-  <div class="form-control mb-6">
-    <%= f.label :email, "登録したメールアドレスを入力してください", class: "label text-sm" %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered w-full bg-gray-100 focus:bg-white", placeholder: "メールアドレス" %>
+<div class="container mx-auto max-w-4xl px-4 py-8 text-gray-700">
+  <div class="text-center mb-8">
+    <h1 class="text-xl font-bold">パスワードをお忘れですか？</h1>
+    <p class="text-sm text-gray-600 mt-2">登録したメールアドレスを入力して、パスワードリセットの手続きを行ってください。</p>
   </div>
 
-  <div class="flex justify-center gap-4">
-  <%= link_to "ログインに戻る", new_session_path(resource_name), class: "btn btn-secondary text-base-100 w-32" %>
-  <%= f.submit "送信", class: "btn btn-primary text-base-100 w-32" %>
-</div>
+  <!-- エラーメッセージの表示 -->
+  <%= render "shared/error_messages", resource: resource %>
 
-<% end %>
+  <!-- パスワードリセットフォーム -->
+  <div class="bg-white p-6 rounded-lg shadow-md">
+    <%= form_with(model: resource, as: resource_name, url: password_path(resource_name), local: true) do |f| %>
+      <div class="space-y-4">
+        <!-- メールアドレス入力 -->
+        <div class="form-control">
+          <%= f.label :email, "登録したメールアドレスを入力してください", class: "block text-sm font-medium text-gray-700" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered w-full bg-gray-100 focus:bg-white text-sm mt-1", placeholder: "メールアドレス" %>
+        </div>
+
+        <!-- 送信ボタンとログインへのリンク -->
+        <div class="flex justify-center gap-4">
+          <%= link_to "ログインに戻る", new_session_path(resource_name), class: "btn btn-secondary text-base-100" %>
+          <%= f.submit "送信", class: "btn btn-primary text-base-100 w-32" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -60,13 +60,20 @@
 
   <!-- 参考URL -->
   <% if @post.reference_url.present? %>
-    <div class="mt-4">
-      <h3 class="text-md font-semibold mb-2">参考URL</h3>
-      <a href="<%= @post.reference_url %>" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:underline">
-        <%= @post.reference_url %>
-      </a>
+    <div class="max-w-sm bg-white rounded-md shadow-sm p-4">
+      <h2 class="text-sm text-gray-700 mb-1">参考URL</h2>
+  
+      <% require 'uri' %>
+      <% uri = URI.parse(@post.reference_url) rescue nil %>
+      <% display_text = uri.present? ? uri.host : @post.reference_url %>
+  
+      <%= link_to display_text, @post.reference_url,
+          target: "_blank",
+          rel: "noopener noreferrer",
+          class: "text-blue-600 hover:underline break-words" %>
     </div>
   <% end %>
+
 
   <!-- タグ -->
   <div class="flex flex-wrap gap-2 mt-4 mb-4">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,19 +44,19 @@ Rails.application.configure do
   # SMTPによるメール送信の設定
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address: 'smtp.gmail.com',
+    address: "smtp.gmail.com",
     port: 587,
-    domain: 'localhost',
-    user_name: ENV['MAILER_SENDER'],
-    password: ENV['MAILER_PASSWORD'],
-    authentication: 'plain',
+    domain: "localhost",
+    user_name: ENV["MAILER_SENDER"],
+    password: ENV["MAILER_PASSWORD"],
+    authentication: "plain",
     enable_starttls_auto: true
   }
 
   # Letter Openerを使った開発環境でのメール確認設定
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,7 +41,22 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  # SMTPによるメール送信の設定
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: 'smtp.gmail.com',
+    port: 587,
+    domain: 'localhost',
+    user_name: ENV['MAILER_SENDER'],
+    password: ENV['MAILER_PASSWORD'],
+    authentication: 'plain',
+    enable_starttls_auto: true
+  }
+
+  # Letter Openerを使った開発環境でのメール確認設定
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,11 +76,22 @@ Rails.application.configure do
 
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
-  config.action_mailer.perform_caching = false
+  # config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.default_url_options = { host: 'https://www.run-breeze.com/' }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              'smtp.gmail.com',
+    port:                 587,
+    domain:               'run-breeze.com',
+    user_name:            ENV['MAILER_SENDER'],
+    password:             ENV['MAILER_PASSWORD'],
+    authentication:       'plain',
+    enable_starttls_auto: true 
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,16 +81,16 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options = { host: 'https://www.run-breeze.com/' }
+  config.action_mailer.default_url_options = { host: "https://www.run-breeze.com/" }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address:              'smtp.gmail.com',
+    address:              "smtp.gmail.com",
     port:                 587,
-    domain:               'run-breeze.com',
-    user_name:            ENV['MAILER_SENDER'],
-    password:             ENV['MAILER_PASSWORD'],
-    authentication:       'plain',
-    enable_starttls_auto: true 
+    domain:               "run-breeze.com",
+    user_name:            ENV["MAILER_SENDER"],
+    password:             ENV["MAILER_PASSWORD"],
+    authentication:       "plain",
+    enable_starttls_auto: true
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -9,6 +9,8 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+  config.mailer_sender = ENV["MAILER_SENDER"] # 送信元メールアドレスを指定
+
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
@@ -24,7 +26,6 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -30,7 +30,7 @@ ja:
     failure:
       already_authenticated: "すでにログインしています"
       unauthenticated: "ログインしてください"
-      invalid: "ログインできませんでした"
+      invalid: "ログインが必要です"
       not_saved: "アカウントが作成できませんでした"
       not_found_in_database: "無効な%{authentication_keys}またはパスワードです。"
     errors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,8 @@ Rails.application.routes.draw do
              controllers: {
                registrations: "users/registrations",
                sessions: "users/sessions",
-               omniauth_callbacks: "users/omniauth_callbacks"
+               omniauth_callbacks: "users/omniauth_callbacks",
+               passwords: "users/passwords"
              }
 
     get "mypage" => "users#mypage", as: :mypage


### PR DESCRIPTION
## 概要
パスワードリセット機能を実装しました。
Deviseの設定変更や、カスタムビューの作成を行い、パスワードリセット用のメール送信やリセットリンクの機能を提供します。

## 行ったこと

1. Deviseのルーティングのカスタマイズ
   - `config/routes.rb` でパスワードリセット用のルートを設定。
2. メールテンプレートのカスタマイズ
   - `app/views/devise/mailer/reset_password_instructions.html.erb` にてメール内容を編集。
3. パスワードリセットビューの調整
   - `app/views/devise/passwords/new.html.erb` をレスポンシブ対応でデザイン。
4. 開発環境でのメール確認方法の設定
   - `letter_opener` を利用して、メール内容を確認可能に。
5. 本番環境のメール送信設定
   - `config/environments/production.rb` にSMTP設定を追加。

## 関連ISSUE

- #116 

## 備考

- 開発環境では `letter_opener` を使用して確認しています。
- 本番環境では、メールが適切に送信されるようにSMTP設定を確認済みです。

