### PR TITLE
Feature/#34 下書き機能の作成

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
   before_action :set_tags, only: [ :new, :edit, :update ]
 
   def index
-    @q = Post.ransack(params[:q])
+    @q = Post.published.ransack(params[:q])
     @posts = @q.result(distinct: true).includes(:tags, :user, :category).order(created_at: :desc).page(params[:page]).per(6)
     @categories = Category.all
   end
@@ -15,13 +15,40 @@ class PostsController < ApplicationController
 
   def create
     @post = current_user.posts.build(post_params)
-    if @post.save
-      # タグの関連付け
-      @post.tag_ids = params[:post][:tag_ids] if params[:post][:tag_ids].present?
-      redirect_to posts_path, notice: "投稿しました"
+    @post.category_id = nil if params[:draft_save].present? && @post.category_id.blank?
+  
+    if params[:draft_save].present?
+      @post.status = :draft
     else
-      flash.now[:danger] = "投稿に失敗しました"
+      @post.status = :published
+    end
+  
+    if @post.save
+      redirect_to(params[:draft_save].present? ? drafts_posts_path : posts_path, notice: "保存しました。")
+    else
+      flash.now[:danger] = "保存に失敗しました。"
       render :new, status: :unprocessable_entity
+    end
+  end  
+  
+  def update
+    # 既存の投稿を取得
+    @post = current_user.posts.find(params[:id])
+  
+    # 下書き保存と公開の分岐
+    if params[:draft_save].present?
+      @post.status = :draft # 下書きとして保存
+      redirect_path = drafts_posts_path # 下書き一覧ページにリダイレクト
+    else
+      @post.status = :published # 公開
+      redirect_path = post_path(@post) # 投稿詳細ページにリダイレクト
+    end
+  
+    if @post.update(post_params)
+      redirect_to redirect_path, notice: params[:draft_save].present? ? "下書きを更新しました。" : "投稿を公開しました。"
+    else
+      flash.now[:danger] = "更新に失敗しました。"
+      render :edit, status: :unprocessable_entity
     end
   end
 
@@ -32,18 +59,13 @@ class PostsController < ApplicationController
   def edit
   end
 
-  def update
-    if @post.update(post_params)
-      redirect_to post_path(@post), notice: "更新しました"
-    else
-      flash.now[:danger] = "更新に失敗しました"
-      render :edit, status: :unprocessable_entity
-    end
-  end
-
   def destroy
     @post.destroy!
     redirect_to posts_path, notice: "削除しました", status: :see_other
+  end
+
+  def drafts
+    @drafts = current_user.posts.draft.order(created_at: :desc).page(params[:page]).per(6)
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -16,25 +16,25 @@ class PostsController < ApplicationController
   def create
     @post = current_user.posts.build(post_params)
     @post.category_id = nil if params[:draft_save].present? && @post.category_id.blank?
-  
+
     if params[:draft_save].present?
       @post.status = :draft
     else
       @post.status = :published
     end
-  
+
     if @post.save
       redirect_to(params[:draft_save].present? ? drafts_posts_path : posts_path, notice: "保存しました。")
     else
       flash.now[:danger] = "保存に失敗しました。"
       render :new, status: :unprocessable_entity
     end
-  end  
-  
+  end
+
   def update
     # 既存の投稿を取得
     @post = current_user.posts.find(params[:id])
-  
+
     # 下書き保存と公開の分岐
     if params[:draft_save].present?
       @post.status = :draft # 下書きとして保存
@@ -43,7 +43,7 @@ class PostsController < ApplicationController
       @post.status = :published # 公開
       redirect_path = post_path(@post) # 投稿詳細ページにリダイレクト
     end
-  
+
     if @post.update(post_params)
       redirect_to redirect_path, notice: params[:draft_save].present? ? "下書きを更新しました。" : "投稿を公開しました。"
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
 
   def mypage
     @user = current_user
+    @posts = @user.posts.published.order(created_at: :desc).page(params[:page]).per(6)
   end
 
   def edit_profile

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -9,9 +9,14 @@ class Post < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :like_users, through: :likes, source: :user
 
-  validates :title, presence: true, length: { maximum: 30 }
-  validates :content, presence: true, length: { maximum: 1000 }
-  validates :category_id, presence: true
+  # 投稿のステータス
+  enum status: { draft: 0, published: 1 }
+
+  validates :title, presence: true, length: { maximum: 30 }, if: :published?
+  validates :content, presence: true, length: { maximum: 1000 }, if: :published?
+  validates :category_id, presence: true, if: :published?
+
+  # タグの選択数を制限
   validate :tag_selection_limit
 
   mount_uploader :post_image, PostImageUploader

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -84,7 +84,8 @@
 
     <!-- 送信ボタン -->
     <div class="flex justify-end space-x-2 mt-4">
-      <%= link_to "キャンセル", cancel_path, class: "btn btn-secondary text-base-100" %>
+      <%= link_to "キャンセル", cancel_path, class: "btn text-gray-700" %>
+      <%= form.submit "下書き保存", name: "draft_save", class: "btn btn-secondary text-base-100" %>
       <%= form.submit submit_button_text, class: "btn btn-primary text-base-100" %>
     </div>
   <% end %>

--- a/app/views/posts/drafts.html.erb
+++ b/app/views/posts/drafts.html.erb
@@ -1,0 +1,16 @@
+<div class="container mx-auto px-4 py-6 bg-base-100 pt-16 pb-20">
+  <h1 class="text-2xl text-gray-700 font-bold mb-6">下書き保存した投稿</h1>
+
+  <% if @drafts.present? %>
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 justify-items-center">
+      <%= render partial: 'posts/post_card', collection: @drafts, as: :post %>
+    </div>
+
+    <!-- ページネーション -->
+    <div class="mt-8 text-center text-sm text-gray-500">
+      <%= paginate @drafts %>
+    </div>
+  <% else %>
+    <p class="text-center text-gray-500 mt-6">現在、下書きはありません。</p>
+  <% end %>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -34,7 +34,7 @@
     <% if @posts.present? %>
       <%= render partial: 'posts/post_card', collection: @posts, as: :post %>
     <% else %>
-      < class="text-center text-gray-600">投稿がありません。</>
+      <p class="text-gray-700 text-center">該当する投稿が見つかりませんでした。</p>
     <% end %>
   </div>
 

--- a/app/views/shared/_after_header_login.html.erb
+++ b/app/views/shared/_after_header_login.html.erb
@@ -29,6 +29,8 @@
         <li>
           <%= link_to 'いいねした投稿', likes_path, class: "btn btn-ghost w-full text-left text-gray-700 hover:bg-gray-100 rounded-md" %>
         </li>
+        <li>
+          <%= link_to '下書き保存した投稿', drafts_posts_path, class: "btn btn-ghost w-full text-left text-gray-700 hover:bg-gray-100 rounded-md" %>
         <hr class="border-gray-200">
         <li>
           <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete, turbo_confirm: "ログアウトしてもよろしいですか？" }, class: "btn btn-ghost w-full text-left text-gray-700 hover:bg-gray-100 rounded-md" %>

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -39,22 +39,22 @@
     <% end %>
   </div>
 
-  <!-- 投稿セクション -->
-  <% if @user.posts.any? %>
-    <div class="bg-base-100 p-6 rounded-lg shadow-md text-left">
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-        <% @user.posts.each do |post| %>
-          <%= render 'posts/post_card', post: post %>
-        <% end %>
-      </div>
+  <!-- ユーザーの投稿一覧 -->
+  <% if @posts.any? %>
+  <div class="bg-base-100 p-6 rounded-lg shadow-md text-left">
+    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+      <% @posts.each do |post| %>
+        <%= render 'posts/post_card', post: post %>
+      <% end %>
     </div>
-  <% else %>
-    <div class="bg-base-100 p-6 rounded-lg shadow-md text-left">
-      <h3 class="text-xm font-semibold mb-4 text-gray-700">投稿一覧</h3>
-      <p class="text-gray-500">まだ投稿がありません。</p>
-    </div>
-  <% end %>
-</div>
+  </div>
+<% else %>
+  <div class="bg-base-100 p-6 rounded-lg shadow-md text-left">
+    <h3 class="text-xm font-semibold mb-4 text-gray-700">投稿一覧</h3>
+    <p class="text-gray-500">まだ投稿がありません。</p>
+  </div>
+<% end %>
+
 
 <!-- パスワードリセットリンク -->
 <div class="mt-6 text-center text-sm text-gray-500">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -34,13 +34,6 @@
     <% end %>
   </div>
 
-  <div class="flex space-x-2">
-    <%= link_to 'プロフィールを編集', edit_profile_path, class: "btn btn-primary btn-xs text-base-100" %>
-    <%= link_to 'パスワードを変更', edit_password_path, class: "btn btn-secondary btn-xs text-base-100" %>
-  </div>
-</div>
-
-
 <!-- 区切り線 -->
 <hr class="my-6 border-gray-300">
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
     resources :comments, only: %i[create], shallow: true
     collection do
       get :bookmarked_posts
+      get :drafts
     end
 
     resources :likes, only: %i[create destroy], shallow: true

--- a/db/migrate/20241213052504_change_status_default_on_posts.rb
+++ b/db/migrate/20241213052504_change_status_default_on_posts.rb
@@ -1,0 +1,8 @@
+class ChangeStatusDefaultOnPosts < ActiveRecord::Migration[7.2]
+  def change
+    change_column_default :posts, :status, from: nil, to: 0
+
+    # nullを許さないように
+    change_column_null :posts, :status, false, 0
+  end
+end

--- a/db/migrate/20241213075129_change_category_id_null_on_posts.rb
+++ b/db/migrate/20241213075129_change_category_id_null_on_posts.rb
@@ -1,0 +1,5 @@
+class ChangeCategoryIdNullOnPosts < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :posts, :category_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_05_054651) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_13_075129) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -63,8 +63,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_05_054651) do
     t.bigint "user_id", null: false
     t.string "title", null: false
     t.text "content", null: false
-    t.bigint "category_id", null: false
-    t.integer "status"
+    t.bigint "category_id"
+    t.integer "status", default: 0, null: false
     t.text "ai_corrected_content"
     t.string "reference_url"
     t.datetime "created_at", null: false


### PR DESCRIPTION
## 概要
下書き機能を実装しました。ユーザーが投稿を下書き状態で保存し、後で編集・公開できるようにする機能です。

## 行ったこと
- `PostsController`に下書き保存用のロジックを追加
  - 下書き一覧ページ用の`drafts`アクションを作成
- 投稿モデルに`status`カラムを追加し、Enumで`draft`と`published`を管理
- 下書き投稿を非表示にするための投稿一覧のフィルタリングを実装
- マイページで下書き投稿を非表示に変更
- 下書き一覧ページのビュー（`drafts.html.erb`）を新規作成
- 下書き保存用のフォームボタンを実装
- `status`カラムのデフォルト値を設定
- `category_id`の`null`制約を緩和

## 関連ISSUE
closed #18