### PR TITLE
プロフィールページをタブ表示から戻す

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,9 +5,6 @@ class UsersController < ApplicationController
   def mypage
     @user = current_user
     @posts = @user.posts.published.order(created_at: :desc).page(params[:page]).per(6)
-    @liked_posts = @user.like_posts.published.order(created_at: :desc).page(params[:liked_page]).per(6)
-    @bookmarked_posts = @user.bookmark_posts.published.order(created_at: :desc).page(params[:bookmarked_page]).per(6)
-    @drafts = @user.posts.draft.order(created_at: :desc).page(params[:draft_page]).per(6)
     @show_edit_button = true
   end
 

--- a/app/views/shared/_after_header_login.html.erb
+++ b/app/views/shared/_after_header_login.html.erb
@@ -8,8 +8,9 @@
     <% end %>
   </div>
 
-  <!-- 投稿するボタン -->
+  <!-- 投稿するボタンとドロップダウンメニュー -->
   <div class="flex-none flex items-center gap-2">
+    <!-- 投稿するボタン -->
     <%= link_to '投稿する！', new_post_path, class: "btn btn-primary text-base-100 italic shadow-sm hover:shadow-md transition-all duration-200" %>
     
     <!-- ドロップダウンメニュー -->
@@ -19,16 +20,23 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
         </svg>
       </label>
+
       <ul tabindex="0" class="dropdown-content menu p-2 shadow-md bg-base-100 rounded-lg w-52 absolute top-full right-0 mt-2 z-50">
+        <!-- ドロップダウンメニュー項目 -->
         <li>
-          <%= link_to 'マイページ', mypage_path, class: "btn btn-ghost w-full text-left text-gray-700 hover:bg-gray-100 rounded-md" %>
+          <%= link_to 'ブックマークした投稿', bookmarks_path, class: "btn btn-ghost w-full text-left text-gray-700 hover:bg-gray-100 rounded-md" %>
         </li>
+        <li>
+          <%= link_to 'いいねした投稿', likes_path, class: "btn btn-ghost w-full text-left text-gray-700 hover:bg-gray-100 rounded-md" %>
+        </li>
+        <li>
+          <%= link_to '下書き保存した投稿', drafts_posts_path, class: "btn btn-ghost w-full text-left text-gray-700 hover:bg-gray-100 rounded-md" %>
+        <hr class="border-gray-200">
         <li>
           <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete, turbo_confirm: "ログアウトしてもよろしいですか？" }, class: "btn btn-ghost w-full text-left text-gray-700 hover:bg-gray-100 rounded-md" %>
         </li>
         <hr class="border-gray-200">
-        <li>
-          <%= link_to '利用規約', terms_of_service_path, class: "btn btn-ghost w-full text-left text-gray-700 hover:bg-gray-100 rounded-md" %>
+        <%= link_to '利用規約', terms_of_service_path, class: "btn btn-ghost w-full text-left text-gray-700 hover:bg-gray-100 rounded-md" %>
         </li>
         <li>
           <%= link_to 'プライバシーポリシー', privacy_policy_path, class: "btn btn-ghost w-full text-left text-gray-700 hover:bg-gray-100 rounded-md" %>

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -1,89 +1,26 @@
 <div class="space-y-8 max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  
   <!-- プロフィール情報セクション -->
   <%= render 'profile', user: @user, show_edit_button: true %>
-  <div role="tablist" class="tabs tabs-bordered overflow-x-auto whitespace-nowrap">
-    <!-- 投稿一覧タブ -->
-    <input type="radio" name="mypage_tabs" role="tab" class="tab" aria-label="投稿" id="tab-posts" checked="checked" />
-    <div role="tabpanel" class="tab-content p-10 inline-block align-top">
-      <% if @posts.any? %>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
-          <% @posts.each do |post| %>
-            <div class="w-full max-w-md">
-              <%= render 'posts/post_card', post: post %>
-            </div>
-          <% end %>
-        </div>
-        <div class="mt-6 flex justify-center">
-          <%= paginate @posts, param_name: :page %>
-        </div>
-      <% else %>
-        <div class="text-gray-500 flex items-center justify-center h-40">
-          <p>まだ投稿がありません。</p>
-        </div>
-      <% end %>
-    </div>
 
-    <!-- いいねした投稿タブ -->
-    <input type="radio" name="mypage_tabs" role="tab" class="tab" aria-label="いいね" id="tab-likes" />
-    <div role="tabpanel" class="tab-content p-10 inline-block align-top">
-      <% if @liked_posts.any? %>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
-          <% @liked_posts.each do |post| %>
-            <div class="w-full max-w-md">
-              <%= render 'posts/post_card', post: post %>
-            </div>
-          <% end %>
-        </div>
-        <div class="mt-6 flex justify-center">
-          <%= paginate @liked_posts, param_name: :liked_page %>
-        </div>
-      <% else %>
-        <div class="text-gray-500 flex items-center justify-center h-40">
-          <p>いいねした投稿はありません。</p>
-        </div>
-      <% end %>
-    </div>
-
-    <!-- ブックマークした投稿タブ -->
-    <input type="radio" name="mypage_tabs" role="tab" class="tab" aria-label="ブックマーク" id="tab-bookmarks" />
-    <div role="tabpanel" class="tab-content p-10 inline-block align-top">
-      <% if @bookmarked_posts.any? %>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
-          <% @bookmarked_posts.each do |post| %>
-            <div class="w-full max-w-md">
-              <%= render 'posts/post_card', post: post %>
-            </div>
-          <% end %>
-        </div>
-        <div class="mt-6 flex justify-center">
-          <%= paginate @bookmarked_posts, param_name: :bookmarked_page %>
-        </div>
-      <% else %>
-        <div class="text-gray-500 flex items-center justify-center h-40">
-          <p>ブックマークした投稿はありません。</p>
-        </div>
-      <% end %>
-    </div>
-
-    <!-- 下書き保存した投稿タブ -->
-    <input type="radio" name="mypage_tabs" role="tab" class="tab" aria-label="下書き" id="tab-drafts" />
-    <div role="tabpanel" class="tab-content p-10 inline-block align-top">
-      <% if @drafts.any? %>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
-          <% @drafts.each do |post| %>
-            <div class="w-full max-w-md">
-              <%= render 'posts/post_card', post: post %>
-            </div>
-          <% end %>
-        </div>
-        <div class="mt-6 flex justify-center">
-          <%= paginate @drafts, param_name: :draft_page %>
-        </div>
-      <% else %>
-        <div class="text-gray-500 flex items-center justify-center h-40">
-          <p>まだ下書きがありません。</p>
-        </div>
-      <% end %>
-    </div>
+  <!-- ユーザーの投稿一覧 -->
+  <div class="bg-base-100 p-6 rounded-lg shadow-md">
+    <h3 class="text-lg font-semibold text-gray-800 mb-4">投稿一覧</h3>
+    <% if @posts.any? %>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        <% @posts.each do |post| %>
+          <%= render 'posts/post_card', post: post %>
+        <% end %>
+      </div>
+      
+      <!-- ページネーションコントロールの追加 -->
+      <div class="mt-6">
+        <%= paginate @posts %>
+      </div>
+    <% else %>
+      <div class="text-gray-500 flex items-center">
+        <p>まだ投稿がありません。</p>
+      </div>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
### 修正
#180 #181 プロフィールページの投稿関係項目をタブで切り替えできるよう実装していたが、本番環境で動作不良を確認したた、プロフィールには投稿一覧のみを表示し、その他の項目についてはヘッダーにて収納するように修正した。

