### PR TITLE
feture/#47_Post_Tagsモデルのテストを作成

### DIFF
--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,4 +1,6 @@
 class PostTag < ApplicationRecord
   belongs_to :post
   belongs_to :tag
+
+  validates :post_id, uniqueness: { scope: :tag_id }
 end

--- a/db/migrate/20250109081336_add_unique_index_to_post_tags.rb
+++ b/db/migrate/20250109081336_add_unique_index_to_post_tags.rb
@@ -1,0 +1,10 @@
+class AddUniqueIndexToPostTags < ActiveRecord::Migration[7.2]
+  def change
+    # 既存の個別インデックスを削除（存在する場合）
+    remove_index :post_tags, :post_id if index_exists?(:post_tags, :post_id)
+    remove_index :post_tags, :tag_id if index_exists?(:post_tags, :tag_id)
+
+    # post_id と tag_id の複合ユニークインデックスを追加
+    add_index :post_tags, [ :post_id, :tag_id ], unique: true, name: 'index_post_tags_on_post_id_and_tag_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,8 @@
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
-ActiveRecord::Schema[7.2].define(version: 2024_12_22_111049) do
+
+ActiveRecord::Schema[7.2].define(version: 2025_01_09_081336) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -63,8 +64,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_22_111049) do
     t.bigint "tag_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["post_id"], name: "index_post_tags_on_post_id"
-    t.index ["tag_id"], name: "index_post_tags_on_tag_id"
+    t.index ["post_id", "tag_id"], name: "index_post_tags_on_post_id_and_tag_id", unique: true
   end
 
   create_table "posts", force: :cascade do |t|
@@ -128,4 +128,3 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_22_111049) do
   add_foreign_key "posts", "users"
   add_foreign_key "tags", "categories"
 end
-

--- a/spec/factories/post_tags.rb
+++ b/spec/factories/post_tags.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+    factory :post_tag do
+      association :post
+      association :tag
+    end
+  end

--- a/spec/models/post_tag_spec.rb
+++ b/spec/models/post_tag_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe PostTag, type: :model do
+  describe 'アソシエーションのテスト' do
+    it { is_expected.to belong_to(:post) }
+    it { is_expected.to belong_to(:tag) }
+  end
+
+  describe '一意性のバリデーションのテスト' do
+    let(:post) { create(:post) }
+    let(:tag) { create(:tag) }
+
+    it '同じpost_idとtag_idの組み合わせは無効である' do
+      # 1つ目のPostTagを作成
+      create(:post_tag, post: post, tag: tag)
+
+      # 2つ目のPostTagを同じ組み合わせで作成
+      duplicate_post_tag = build(:post_tag, post: post, tag: tag)
+      duplicate_post_tag.validate # バリデーションを手動でトリガー
+
+      # エラーメッセージを動的に取得
+      error_message = I18n.t('errors.messages.taken')
+      expect(duplicate_post_tag.errors[:post_id]).to include(error_message)
+    end
+
+    it '異なるpost_idやtag_idの組み合わせは有効である' do
+      # 異なる組み合わせのPostTagを作成
+      create(:post_tag, post: post, tag: tag)
+
+      other_post = create(:post)
+      other_tag = create(:tag)
+
+      valid_post_tag = build(:post_tag, post: other_post, tag: other_tag)
+
+      # 有効であることを確認
+      expect(valid_post_tag).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
### 概要
PostTagsモデルに対する一意性バリデーションとテストを追加しました。

### 行ったこと
- PostTagsモデルに一意性バリデーションを追加
  - `post_id`と`tag_id`の組み合わせがユニークであることを検証
- PostTagsテーブルに一意性制約（複合インデックス）を追加
  - `db/migrate/20250109081336_add_unique_index_to_post_tags.rb`を作成
- PostTagsモデルに対するテストを追加
  - 一意性バリデーションのテスト
  - アソシエーションのテスト
- FactoryBotのファクトリーを追加（`spec/factories/post_tags.rb`）

### 関連ISSUE
- Close #203 