### PR TITLE
feature/#50_commentモデルのテストを作成

### DIFF
--- a/db/migrate/20250109093730_add_null_constraint_to_comments_content.rb
+++ b/db/migrate/20250109093730_add_null_constraint_to_comments_content.rb
@@ -1,0 +1,5 @@
+class AddNullConstraintToCommentsContent < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :comments, :content, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_09_081336) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_09_093730) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,7 +40,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_09_081336) do
   end
 
   create_table "comments", force: :cascade do |t|
-    t.text "content"
+    t.text "content", null: false
     t.bigint "post_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+    factory :comment do
+      content { "テストコメント" }
+      association :user
+      association :post
+    end
+  end
+  

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -5,4 +5,3 @@ FactoryBot.define do
       association :post
     end
   end
-  

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  describe 'アソシエーションのテスト' do
+    it { is_expected.to belong_to(:post) }
+    it { is_expected.to belong_to(:user) }
+  end
+
+  describe 'バリデーションのテスト' do
+    let(:user) { create(:user) }
+    let(:post) { create(:post) }
+    let(:comment) { build(:comment, user: user, post: post) }
+
+    context 'コメント内容のバリデーション' do
+      it 'コメントが有効である場合' do
+        expect(comment).to be_valid
+      end
+
+      it 'コメントが空の場合は無効である' do
+        comment.content = nil
+        expect(comment).not_to be_valid
+        expect(comment.errors[:content]).to include('を入力してください')
+      end
+
+      it 'コメントが300文字以内の場合は有効である' do
+        comment.content = 'a' * 300
+        expect(comment).to be_valid
+      end
+
+      it 'コメントが300文字を超える場合は無効である' do
+        comment.content = 'a' * 301
+        expect(comment).not_to be_valid
+        expect(comment.errors[:content]).to include('は300文字以内で入力してください')
+      end
+    end
+
+    describe '関連するレコードの削除' do
+      it '投稿が削除されると関連するコメントも削除される' do
+        post = create(:post)
+        comment = create(:comment, post: post)
+        expect { post.destroy }.to change(Comment, :count).by(-1)
+      end
+
+      it 'ユーザーが削除されると関連するコメントも削除される' do
+        user = create(:user)
+        comment = create(:comment, user: user)
+        expect { user.destroy }.to change(Comment, :count).by(-1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### 概要
`Comment`モデルに対するテストを作成しました。

### 行ったこと
1. コメント内容(`content`)に`null: false`制約を追加
   - コメントが空で保存されるのを防ぐため、`db/migrate`を作成し、制約を追加しました。
   - `db/schema.rb`を更新。
2. `Comment`モデルのファクトリーを作成
   - FactoryBotを利用してテストデータを生成可能にしました。
3. `Comment`モデルのテストを作成
   - アソシエーションのテスト
   - コメント内容(`content`)のバリデーションテスト
   - 投稿およびユーザーが削除された場合、関連するコメントが削除されることのテスト

### 関連ISSUE
- Close #126 