### PR TITLE
feature/#51_adviceモデルのテストを作成

### DIFF
--- a/app/models/advice.rb
+++ b/app/models/advice.rb
@@ -1,5 +1,6 @@
 class Advice < ApplicationRecord
   belongs_to :user
 
-  validates :input, presence: true
+  validates :input, presence: true, length: { maximum: 500 }
+  validates :response, length: { maximum: 800 }, allow_blank: true
 end

--- a/spec/factories/advices.rb
+++ b/spec/factories/advices.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+    factory :advice do
+      input { "サンプルの質問内容" }
+      response { "サンプルの回答" }
+      association :user
+    end
+  end

--- a/spec/models/advice_spec.rb
+++ b/spec/models/advice_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe Advice, type: :model do
+  describe 'アソシエーションのテスト' do
+    it { is_expected.to belong_to(:user) }
+  end
+
+  describe 'バリデーションのテスト' do
+    subject { build(:advice) }  # FactoryBotのファクトリーを使用
+
+    it { is_expected.to validate_presence_of(:input) }
+
+    it 'ユーザーが存在しなければ無効である' do
+      subject.user = nil
+      expect(subject).not_to be_valid
+      expect(subject.errors[:user]).to include('を入力してください')
+    end
+
+    it '質問内容が500文字以内の場合は有効である' do
+      subject.input = 'a' * 500
+      expect(subject).to be_valid
+    end
+
+    it '質問内容が500文字を超える場合は無効である' do
+      subject.input = 'a' * 501
+      expect(subject).not_to be_valid
+      expect(subject.errors[:input]).to include('は500文字以内で入力してください')
+    end
+
+    context 'responseのバリデーション' do
+      it 'responseが800文字以内の場合は有効である' do
+        subject.response = 'a' * 800
+        expect(subject).to be_valid
+      end
+
+      it 'responseが800文字を超える場合は無効である' do
+        subject.response = 'a' * 801
+        expect(subject).not_to be_valid
+        expect(subject.errors[:response]).to include('は800文字以内で入力してください')
+      end
+
+      it 'responseがnilの場合でも有効である' do
+        subject.response = nil
+        expect(subject).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
### 概要
`Advice`モデルに対するテストを作成しました。

### 行ったこと
1. `Advice`モデルのアソシエーションテストを追加
   - ユーザーとの関連付けを確認。
2. `Advice`モデルのバリデーションテストを追加
   - `input`の存在必須バリデーションを確認。
   - `input`の最大文字数（500文字）制限を確認。
   - `response`の最大文字数（800文字）制限を確認。
   - `response`が`nil`の場合も有効であることを確認。
3. `FactoryBot`を利用したファクトリーを作成
   - `Advice`モデルのテストデータ生成用に`spec/factories/advices.rb`を作成。

### 関連ISSUE
- Close #206 
